### PR TITLE
Bug fix: Prevent enum value namespace collisions

### DIFF
--- a/src/graphqlSafeEnumKey.ts
+++ b/src/graphqlSafeEnumKey.ts
@@ -5,13 +5,15 @@ export function graphqlSafeEnumKey(value: string): string {
   const trim = (s: string) => s.trim()
   const isNum = (s: string): boolean => /^[0-9]/.test(s)
   const safeNum = (s: string): string => (isNum(s) ? `VALUE_${s}` : s)
-  const convertComparators = (s: string): string =>
-    ({
+  const convertComparators = (s: string): string => {
+    const comparators = {
       '<': 'LT',
       '<=': 'LTE',
       '>=': 'GTE',
       '>': 'GT',
-    }[s] || s)
+    };
+    return Object.keys(comparators).includes(s) ? comparators[s] : s;
+  }
   const sanitize = (s: string) => s.replace(/[^_a-zA-Z0-9]/g, '_')
   return R.compose(
     sanitize,

--- a/test/convert.test.ts
+++ b/test/convert.test.ts
@@ -493,6 +493,31 @@ test('handles enum with numeric keys', () => {
   testConversion(jsonSchema, expectedSchemaText)
 })
 
+test('handles enum with namespace overlapping JS Object internals', () => {
+  const jsonSchema: JSONSchema7 = {
+    $id: 'Comparator',
+    type: 'object',
+    properties: {
+      operator: {
+        type: 'string',
+        enum: ['constructor', '__proto__']
+      },
+    },
+  }
+  const expectedSchemaText = `
+    type Comparator {
+      operator: ComparatorOperator
+    }
+    enum ComparatorOperator {
+      constructor
+      __proto__
+    }
+    type Query {
+      comparators: [Comparator]
+    }`
+  testConversion(jsonSchema, expectedSchemaText)
+})
+
 test('fails on enum for non-string properties', () => {
   const jsonSchema: JSONSchema7 = {
     $id: 'Person',


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

Certain enum values collide with JS's object namespace, e.g. `"constructor"`

* **What is the new behavior (if this is a feature change)?**

Only actual comparator values are identified as comparators.