### PR TITLE
Oneof with anonymous object

### DIFF
--- a/src/schemaReducer.ts
+++ b/src/schemaReducer.ts
@@ -49,7 +49,7 @@ function buildType(propName: string, schema: JSONSchema7, knownTypes: GraphQLTyp
     const caseKeys = Object.keys(cases)
     const types: GraphQLObjectType[] = caseKeys.map((caseName: string) => {
       const caseSchema = cases[caseName]
-      const qualifiedName = `${name}.oneOf[${caseName}]`
+      const qualifiedName = `${name}_${caseName}`
       const typeSchema = (caseSchema.then || caseSchema) as JSONSchema7
       return buildType(qualifiedName, typeSchema, knownTypes) as GraphQLObjectType
     })

--- a/test/convert.test.ts
+++ b/test/convert.test.ts
@@ -631,6 +631,36 @@ test('converts `oneOf` schemas to union types', () => {
   testConversion([parent, child, person], expectedSchemaText)
 })
 
+test('handles `oneOf` schemas that include anonymous types', () => {
+  const thing: JSONSchema7 = {
+    $id: '#/Thing',
+    oneOf: [
+      {
+        type: 'string',
+      },
+      {
+        type: 'object',
+        properties: {
+          foo: {
+            type: 'string',
+          },
+        },
+      },
+    ],
+  }
+
+  const expectedSchemaText = `
+    type Query {
+      things: [Thing]
+    }
+    union Thing = String | Thing1
+    type Thing1 {
+      foo: String
+    }
+  `
+  testConversion(thing, expectedSchemaText)
+})
+
 //
 // Family tests
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

fixes #4

* **Other information**:

Was creating a qualified name for anonymous objects using brackets; changed to using underscores as delimiters, which disappear when the name is UpperCamelCased. 
